### PR TITLE
virtio: net: read mac byte by byte

### DIFF
--- a/src/lib/virtio/src/virtio_net.rs
+++ b/src/lib/virtio/src/virtio_net.rs
@@ -142,13 +142,8 @@ impl NetDev {
             .as_ref()
             .unwrap();
 
-        let mac_0_4: u32 = cfg_bar.read_u32(device_cfg.offset as u64 + 0);
-        let mac_4_6: u16 = cfg_bar.read_u16(device_cfg.offset as u64 + 4);
-        for idx in 0..4 {
-            self.mac[idx] = unsafe { *(((&mac_0_4 as *const _ as usize) + idx) as *const u8) };
-        }
-        for idx in 4..6 {
-            self.mac[idx] = unsafe { *(((&mac_4_6 as *const _ as usize) + idx - 4) as *const u8) };
+        for (index, b) in self.mac.iter_mut().enumerate() {
+            *b = cfg_bar.readb(device_cfg.offset as u64 + index as u64);
         }
 
         #[cfg(debug_assertions)]


### PR DESCRIPTION
As per virtio spec 4.1.3.1 [1]:

> For device configuration access, the driver MUST use 8-bit wide
> accesses for 8-bit wide fields, 16-bit wide and aligned accesses for
> 16-bit wide fields and 32-bit wide and aligned accesses for 32-bit
> and 64-bit wide fields.

This patch lets the virtio net driver read mac byte by byte to align with the spec.

[1] https://docs.oasis-open.org/virtio/virtio/v1.2/csd01/virtio-v1.2-csd01.html#x1-1220001