### PR TITLE
virtio-pci: enable I/O and memory sapce

### DIFF
--- a/src/lib/virtio/src/pci.rs
+++ b/src/lib/virtio/src/pci.rs
@@ -18,6 +18,8 @@ pub const PCI_CAP_VENDOR: u8 = 0x09;
 pub const PCI_CAP_MSIX: u8 = 0x11;
 
 pub const PCI_CFG_COMMAND: u8 = 0x04;
+pub const PCI_COMMAND_BUS_IO: u16 = 0x01;
+pub const PCI_COMMAND_BUS_MEM: u16 = 0x02;
 pub const PCI_COMMAND_BUS_MASTER: u16 = 0x04;
 pub const PCI_COMMAND_INTX_DISABLE: u16 = 0x400;
 

--- a/src/lib/virtio/src/virtio_device.rs
+++ b/src/lib/virtio/src/virtio_device.rs
@@ -286,9 +286,9 @@ impl VirtioDevice {
 
     // Step 0: see virtio_pci_device::init() in osv.
     fn init(&mut self) {
-        // Set bus master.
+        // Set bus master, enable I/O and memory space.
         let mut command = self.pci_device.id.read_config_u16(pci::PCI_CFG_COMMAND);
-        command |= pci::PCI_COMMAND_BUS_MASTER;
+        command |= pci::PCI_COMMAND_BUS_MASTER | pci::PCI_COMMAND_BUS_IO | pci::PCI_COMMAND_BUS_MEM;
         self.pci_device
             .id
             .write_config_u16(pci::PCI_CFG_COMMAND, command);


### PR DESCRIPTION
As per PCIe Spec v6.1 Sec 7.5.1.1.3 Table 7-4, the default values of the memory and I/O space bits of the Command register are 0.

Although some hypervisors may turn on these bits before booting the guest, the guest should better set these 2 bits explicitly.