### PR TITLE
Use `&mut [MaybeUninit<u8>]` for write-only buffers

### DIFF
--- a/src/sys/kernel/src/arch/x64/time.rs
+++ b/src/sys/kernel/src/arch/x64/time.rs
@@ -1,4 +1,3 @@
-use core::mem::MaybeUninit;
 use core::sync::atomic::*;
 
 use core::arch::asm;
@@ -327,4 +326,4 @@ struct PvClockVcpuTimeInfo {
     pad: [u8; 2],
 }
 
-static GLOBALS: Globals = unsafe { MaybeUninit::<Globals>::zeroed().assume_init() };
+static GLOBALS: Globals = unsafe { core::mem::zeroed() };

--- a/src/sys/kernel/src/util/unsafe_ref.rs
+++ b/src/sys/kernel/src/util/unsafe_ref.rs
@@ -17,10 +17,7 @@ pub struct UnsafeRef<T> {
 
 impl<T> Default for UnsafeRef<T> {
     fn default() -> Self {
-        Self {
-            addr: 0,
-            foo_: PhantomData,
-        }
+        Self::const_default()
     }
 }
 
@@ -28,7 +25,7 @@ impl<T> UnsafeRef<T> {
     pub const fn const_default() -> Self {
         Self {
             addr: 0,
-            foo_: unsafe { core::mem::MaybeUninit::<PhantomData<T>>::zeroed().assume_init() },
+            foo_: PhantomData,
         }
     }
 

--- a/src/sys/lib/moto-ipc/src/io_channel.rs
+++ b/src/sys/lib/moto-ipc/src/io_channel.rs
@@ -133,7 +133,7 @@ impl Default for Msg {
 
 impl Msg {
     pub fn new() -> Self {
-        let mut result: Self = unsafe { core::mem::MaybeUninit::zeroed().assume_init() };
+        let mut result: Self = unsafe { core::mem::zeroed() };
         result.status = moto_rt::E_NOT_READY;
         result
     }

--- a/src/sys/lib/moto-ipc/src/lib.rs
+++ b/src/sys/lib/moto-ipc/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![feature(maybe_uninit_write_slice)]
 
 extern crate alloc;
 

--- a/src/sys/lib/rt.vdso/src/main.rs
+++ b/src/sys/lib/rt.vdso/src/main.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 #![allow(unused)]
+#![feature(maybe_uninit_write_slice)]
 #![feature(str_from_raw_parts)]
 
 mod load;

--- a/src/sys/lib/rt.vdso/src/net/rt_net.rs
+++ b/src/sys/lib/rt.vdso/src/net/rt_net.rs
@@ -195,7 +195,7 @@ pub extern "C" fn peek(rt_fd: i32, buf: *mut u8, buf_sz: usize) -> i64 {
         return -(E_BAD_HANDLE as i64);
     };
 
-    let buf = unsafe { core::slice::from_raw_parts_mut(buf, buf_sz) };
+    let buf = unsafe { core::slice::from_raw_parts_mut(buf.cast(), buf_sz) };
 
     if let Some(tcp_stream) = (posix_file.as_ref() as &dyn Any).downcast_ref::<TcpStream>() {
         match tcp_stream.peek(buf) {
@@ -303,7 +303,7 @@ unsafe fn udp_recv_or_peek_from(
         return -(E_BAD_HANDLE as i64);
     };
 
-    let buf = core::slice::from_raw_parts_mut(buf, buf_sz);
+    let buf = core::slice::from_raw_parts_mut(buf.cast(), buf_sz);
     match udp_socket.recv_or_peek_from(buf, peek) {
         Ok((sz, from)) => {
             *addr = from.into();


### PR DESCRIPTION
Currently, the operational semantics are vague on whether the values pointed to by a reference must be fully initialized. Tentatively, Rust does *not* have full recursive validity for references (https://github.com/rust-lang/unsafe-code-guidelines/issues/412), so having a `&mut [u8]` slice would not guarantee that its elements are initialized, but this is not official, so we cannot rely on it. More strictly, the safety documentation for `core::slice::from_raw_parts_mut` requires that it points to len number of initialized values. To be safe, use `&mut [MaybeUninit<u8>]`.

This will enable passing possibly-uninitialized memory to these `read`-like system calls, to implement `Read::read_buf` in the standard library.