### PR TITLE
Simplifications and `posix_read_vectored` precondition fix

### DIFF
--- a/src/bin/httpd/src/main.rs
+++ b/src/bin/httpd/src/main.rs
@@ -61,11 +61,7 @@ fn get_txt_file(pb: PathBuf) -> Option<String> {
     // Try cache hit.
     {
         let mut cache = TXT_FILE_CACHE.lock().unwrap();
-        if cache.is_none() {
-            *cache = Some(HashMap::new());
-        }
-
-        let map = cache.as_mut().unwrap();
+        let map = cache.get_or_insert_default();
         if let Some(s) = map.get(&pb) {
             return Some(s.clone());
         }
@@ -110,11 +106,7 @@ fn get_img_file(pb: PathBuf) -> Option<Vec<u8>> {
     // Try cache hit.
     {
         let mut cache = IMG_FILE_CACHE.lock().unwrap();
-        if cache.is_none() {
-            *cache = Some(HashMap::new());
-        }
-
-        let map = cache.as_mut().unwrap();
+        let map = cache.get_or_insert_default();
         if let Some(v) = map.get(&pb) {
             return Some(v.clone());
         }
@@ -463,7 +455,6 @@ impl std::io::Read for ClientConnection {
                     Err(err) => {
                         if err.kind() == std::io::ErrorKind::WouldBlock {
                             tls_conn.complete_io(tcp_stream)?;
-                            continue;
                         }
                     }
                 }

--- a/src/bin/rnetbench/src/main.rs
+++ b/src/bin/rnetbench/src/main.rs
@@ -99,9 +99,8 @@ fn do_throughput_read(mut stream: TcpStream, client_args: Option<&Args>) -> (Dur
                 break;
             }
         }
-        let bytes_read = match stream.read(&mut buffer) {
-            Ok(n) => n,
-            Err(_) => break,
+        let Ok(bytes_read) = stream.read(&mut buffer) else {
+            break;
         };
         if bytes_read == 0 {
             break;

--- a/src/imager/src/util.rs
+++ b/src/imager/src/util.rs
@@ -18,14 +18,13 @@ pub async fn _motor_fs_create_dir_all(fs: &mut MotorFs, path: &Path) -> std::io:
         }
 
         let entry_id = fs.stat(parent_id, filename).await.unwrap();
-        if let Some(entry_id) = entry_id {
-            parent_id = entry_id;
+        parent_id = if let Some(entry_id) = entry_id {
+            entry_id
         } else {
-            parent_id = fs
-                .create_entry(parent_id, srfs::EntryKind::Directory, filename)
+            fs.create_entry(parent_id, srfs::EntryKind::Directory, filename)
                 .await
-                .unwrap();
-        }
+                .unwrap()
+        };
     }
 
     Ok(parent_id)

--- a/src/sys/lib/rt.vdso/src/posix.rs
+++ b/src/sys/lib/rt.vdso/src/posix.rs
@@ -86,9 +86,7 @@ pub trait PosixFile: Any + Send + Sync {
 }
 
 pub extern "C" fn posix_read(rt_fd: i32, buf: *mut u8, buf_sz: usize) -> i64 {
-    let posix_file = if let Some(fd) = get_file(rt_fd) {
-        fd
-    } else {
+    let Some(posix_file) = get_file(rt_fd) else {
         return -(E_BAD_HANDLE as i64);
     };
 
@@ -100,9 +98,7 @@ pub extern "C" fn posix_read(rt_fd: i32, buf: *mut u8, buf_sz: usize) -> i64 {
 }
 
 pub unsafe extern "C" fn posix_read_vectored(rt_fd: i32, packed: *const usize, num: usize) -> i64 {
-    let posix_file = if let Some(fd) = get_file(rt_fd) {
-        fd
-    } else {
+    let Some(posix_file) = get_file(rt_fd) else {
         return -(E_BAD_HANDLE as i64);
     };
 
@@ -122,9 +118,7 @@ pub unsafe extern "C" fn posix_read_vectored(rt_fd: i32, packed: *const usize, n
 }
 
 pub extern "C" fn posix_write(rt_fd: i32, buf: *const u8, buf_sz: usize) -> i64 {
-    let posix_file = if let Some(fd) = get_file(rt_fd) {
-        fd
-    } else {
+    let Some(posix_file) = get_file(rt_fd) else {
         return -(E_BAD_HANDLE as i64);
     };
 
@@ -136,9 +130,7 @@ pub extern "C" fn posix_write(rt_fd: i32, buf: *const u8, buf_sz: usize) -> i64 
 }
 
 pub unsafe extern "C" fn posix_write_vectored(rt_fd: i32, packed: *const usize, num: usize) -> i64 {
-    let posix_file = if let Some(fd) = get_file(rt_fd) {
-        fd
-    } else {
+    let Some(posix_file) = get_file(rt_fd) else {
         return -(E_BAD_HANDLE as i64);
     };
 
@@ -158,9 +150,7 @@ pub unsafe extern "C" fn posix_write_vectored(rt_fd: i32, packed: *const usize, 
 }
 
 pub extern "C" fn posix_flush(rt_fd: i32) -> ErrorCode {
-    let posix_file = if let Some(fd) = get_file(rt_fd) {
-        fd
-    } else {
+    let Some(posix_file) = get_file(rt_fd) else {
         return E_BAD_HANDLE;
     };
 
@@ -171,9 +161,7 @@ pub extern "C" fn posix_flush(rt_fd: i32) -> ErrorCode {
 }
 
 pub extern "C" fn posix_close(rt_fd: i32) -> ErrorCode {
-    let posix_file = if let Some(fd) = pop_file(rt_fd) {
-        fd
-    } else {
+    let Some(posix_file) = pop_file(rt_fd) else {
         return E_BAD_HANDLE;
     };
 
@@ -184,9 +172,7 @@ pub extern "C" fn posix_close(rt_fd: i32) -> ErrorCode {
 }
 
 pub extern "C" fn posix_duplicate(rt_fd: RtFd) -> RtFd {
-    let posix_file = if let Some(fd) = get_file(rt_fd) {
-        fd
-    } else {
+    let Some(posix_file) = get_file(rt_fd) else {
         return -(E_BAD_HANDLE as RtFd);
     };
 


### PR DESCRIPTION
Some minor simplifications I've cherry-picked from other work, as well as removing an incorrect precondition for `posix_read_vectored`. That precondition assumes that `num` describes the number of `usize` elements, but it describes the number of `usize` pair elements. `posix_read_vectored` is unchanged since its implementation in 94770ad (rt/vdso: implement read/write vectored, 2025-01-02), so it's presumably an artifact of a WIP state.