### PR TITLE
Pull out path constants from imager into yml file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ rnetbench:
 
 img: boot core sys user
 	cd src/imager && \
-		cargo run $(CARGO_RELEASE) -- "$(ROOT_DIR)" $(IMG_CMD)
+		cargo run $(CARGO_RELEASE) -- "$(ROOT_DIR)" $(IMG_CMD) full.config.yaml web.config.yaml motor.full.config.yaml 
 	cp "$(ROOT_DIR)/src/vm_scripts/"* \
 		"$(ROOT_DIR)/vm_images/$(IMG_CMD)/"
 	chmod 400 "$(ROOT_DIR)/vm_images/$(IMG_CMD)/test.key"

--- a/docs/build.md
+++ b/docs/build.md
@@ -124,7 +124,11 @@ cd $MOTORH/motor-os/vm_images/release
 ./run-qemu.sh
 ```
 
-to run Motor OS in qemu.
+to run Motor OS in qemu. This launches the full image by default. To use the `web` image, run
+
+```sh
+./run-qemu.sh --img=motor.web.img
+```
 
 While Motor OS is running, you can ssh into it using
 `ssh-into-motor-os-vm.sh` script, or via

--- a/src/imager/Cargo.lock
+++ b/src/imager/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "motor-fs",
  "srfs",
  "tokio",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -290,6 +291,12 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "log"
@@ -736,4 +743,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]

--- a/src/imager/Cargo.toml
+++ b/src/imager/Cargo.toml
@@ -14,4 +14,5 @@ srfs     = { path = "../sys/lib/srfs"    }
 env_logger = "0.11"
 camino     = "1.1.10"
 mbrman     = "0.5.2"
+yaml-rust  = "0.4.5"
 tokio      = { version = "1.44.2", default-features = false, features = ["rt"] }

--- a/src/imager/full.config.yaml
+++ b/src/imager/full.config.yaml
@@ -1,0 +1,24 @@
+img_files: full
+binaries:
+  - "/bin/httpd"
+  - "/bin/httpd-axum"
+  - "/bin/russhd"
+  - "/bin/kibim"
+  - "/bin/rush"
+  - "/sys/mdbg"
+  - "/sys/sys-init"
+  - "/sys/sys-log"
+  - "/sys/sys-tty"
+  - "/sys/sysbox"
+  - "/sys/tests/rnetbench"
+  - "/sys/tests/systest"
+  - "/sys/tests/mio-test"
+  - "/sys/tests/tokio-tests"
+  - "/sys/tests/crossbench"
+filesystem:
+  type: "srfs"
+  filename: "motor.full.img"
+  partition_name: "fs_part.full"
+constants:
+  img_out_dir: "vm_images"
+  static_files_dir: "img_files"

--- a/src/imager/motor.full.config.yaml
+++ b/src/imager/motor.full.config.yaml
@@ -1,0 +1,24 @@
+img_files: full
+binaries:
+  - "/bin/httpd"
+  - "/bin/httpd-axum"
+  - "/bin/russhd"
+  - "/bin/kibim"
+  - "/bin/rush"
+  - "/sys/mdbg"
+  - "/sys/sys-init"
+  - "/sys/sys-log"
+  - "/sys/sys-tty"
+  - "/sys/sysbox"
+  - "/sys/tests/rnetbench"
+  - "/sys/tests/systest"
+  - "/sys/tests/mio-test"
+  - "/sys/tests/tokio-tests"
+  - "/sys/tests/crossbench"
+filesystem:
+  type: "motor-fs"
+  filename: "motor-fs"
+  partition_name: "fs_part.web.motor-fs"
+constants:
+  img_out_dir: "vm_images"
+  static_files_dir: "img_files"

--- a/src/imager/src/config.rs
+++ b/src/imager/src/config.rs
@@ -1,0 +1,102 @@
+use std::{fs, path::PathBuf};
+use yaml_rust::{Yaml, YamlLoader};
+
+pub(crate) struct ImageConfig {
+    pub(crate) img_files: String,
+    pub(crate) binaries: Vec<String>,
+    pub(crate) fs_type: String,
+    pub(crate) fs_partition_name: String,
+    pub(crate) filename: String,
+}
+
+pub(crate) struct ImagerConfig {
+    img_out_dir: PathBuf,
+    static_files_dir: PathBuf,
+    image: ImageConfig,
+}
+
+impl ImagerConfig {
+    pub(crate) fn load(path: &PathBuf) -> Option<Self> {
+        if !path.exists() {
+            // check for it on the imager folder
+            let mut alt_path = get_crate_root();
+            alt_path.push(path);
+            if !alt_path.exists() {
+                return None;
+            }
+            return Self::load(&alt_path);
+        }
+        let contents = fs::read_to_string(path).ok()?;
+        Some(contents.into())
+    }
+
+    pub(crate) fn img_out_dir(&self) -> &PathBuf {
+        &self.img_out_dir
+    }
+
+    pub(crate) fn static_files_dir(&self) -> &PathBuf {
+        &self.static_files_dir
+    }
+
+    pub(crate) fn image(&self) -> &ImageConfig {
+        &self.image
+    }
+}
+
+impl From<String> for ImagerConfig {
+    fn from(src: String) -> Self {
+        let docs = YamlLoader::load_from_str(&src).unwrap();
+        let doc = &docs[0];
+
+        // constants
+        let constants = doc["constants"].as_hash().unwrap();
+        let img_out_dir = constants[&Yaml::String("img_out_dir".into())].as_str().unwrap().to_string();
+        let static_files_dir = constants[&Yaml::String("static_files_dir".into())].as_str().unwrap().to_string();
+        
+        // top-level name
+        let img_files = doc["img_files"].as_str().unwrap().to_string();
+
+        // binaries
+        let binaries = doc["binaries"]
+            .as_vec()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect::<Vec<String>>();
+
+        // filesystem block
+        let fs = doc["filesystem"].as_hash().unwrap();
+
+        let fs_type = fs[&Yaml::String("type".into())].as_str().unwrap().to_string();
+        let filename = fs[&Yaml::String("filename".into())].as_str().unwrap().to_string();
+        let fs_partition_name = fs[&Yaml::String("partition_name".into())].as_str().unwrap().to_string();
+
+        let image = ImageConfig {
+            img_files,
+            binaries,
+            fs_type,
+            fs_partition_name,
+            filename,
+        };
+
+        Self {
+            img_out_dir: PathBuf::from(img_out_dir),
+            static_files_dir: PathBuf::from(static_files_dir),
+            image,
+        }
+    }
+}
+
+fn get_crate_root() -> PathBuf {
+    let file_path = PathBuf::from(file!());
+    file_path.parent().unwrap().parent().unwrap().to_path_buf()
+}
+
+impl Default for ImagerConfig {
+    fn default() -> Self {
+        let config_path = get_crate_root()
+            .join("full.config.yaml");
+
+        Self::load(&config_path).expect("Expected full.config.yaml at the root of the imager crate")
+    }
+}

--- a/src/imager/web.config.yaml
+++ b/src/imager/web.config.yaml
@@ -1,0 +1,12 @@
+img_files: web
+binaries:
+  - "/bin/httpd-axum"
+  - "/sys/sys-init"
+  - "/sys/sys-tty"
+filesystem:
+  type: "flatfs"
+  filename: "motor.web.img"
+  partition_name: "fs_part.web"
+constants:
+  img_out_dir: "vm_images"
+  static_files_dir: "img_files"

--- a/src/vm_scripts/run-qemu.sh
+++ b/src/vm_scripts/run-qemu.sh
@@ -1,11 +1,18 @@
 #!/bin/sh
 
 WD="$(dirname $0)"
+# the script allows for --img=<image-file> to be passed as first argument
+# if this exists, should be stripped from "$@" before passing to qemu
+IMG="motor.full.img"
+if [ "${1#--img=}" != "$1" ]; then
+  IMG="${1#--img=}"
+  shift
+fi
 
 qemu-system-x86_64 -m 256M -enable-kvm -cpu host -smp 4 \
   -device isa-debug-exit,iobase=0xf4,iosize=0x04 \
   -device virtio-blk-pci,drive=drive0,id=virtblk0,num-queues=1,disable-legacy=on \
-  -drive "file=$WD/motor.full.img,if=none,id=drive0,format=raw" \
+  -drive "file=$WD/$IMG,if=none,id=drive0,format=raw" \
   -netdev tap,ifname=moto-tap,script=no,downscript=no,id=nic0 \
   -device virtio-net-pci,disable-legacy=on,mac=a4:a1:c2:00:00:01,netdev=nic0 \
   -no-reboot -nographic "$@"


### PR DESCRIPTION
Paths to binaries were hardcoded in imager. They have been pulled out into a yml file. At build time, the file is parsed and imported as constants into the imager code.

Furthermore, the folder name for the output of the images is included in the config file, as well as the path to static files to be included.

Issue: https://github.com/moturus/motor-os/issues/24