### PR TITLE
Rush basic autocompletion for builtin commands

### DIFF
--- a/src/bin/rush/src/autocomplete.rs
+++ b/src/bin/rush/src/autocomplete.rs
@@ -1,0 +1,12 @@
+//! Autocompletion logic
+//! It gets engaged when you press Tab after entering partial command and does the following:
+//! - if there're no spaces in the line - lookup respective binary
+//! - if there're spaces - extract first argument as a binary and call a helper for the command
+
+pub fn try_complete(partial_cmdline: &str) -> Option<String> {
+    if partial_cmdline.is_empty() {
+        return None; // nothing to complete
+    }
+
+    todo!("tokenize")
+}

--- a/src/bin/rush/src/autocomplete.rs
+++ b/src/bin/rush/src/autocomplete.rs
@@ -1,12 +1,121 @@
 //! Autocompletion logic
+//! TODO: update the desc
 //! It gets engaged when you press Tab after entering partial command and does the following:
 //! - if there're no spaces in the line - lookup respective binary
 //! - if there're spaces - extract first argument as a binary and call a helper for the command
+//!
 
-pub fn try_complete(partial_cmdline: &str) -> Option<String> {
+use std::{collections::HashMap, sync::LazyLock};
+
+use crate::line_parser;
+
+static COMMANDS: LazyLock<Trie> = LazyLock::new(|| {
+    let mut t = Trie::new();
+    // TODO:  fill the list from the OG source
+    for command in ["cd", "ps", "pwd", "ls"] {
+        t.insert(command);
+    }
+    t
+});
+
+/// tries to complete last token of the command line
+/// # Returns
+/// None if there's nothing that could be completed
+/// Some(all possible lines) if there're options
+pub fn try_complete(partial_cmdline: &str) -> Option<Vec<String>> {
     if partial_cmdline.is_empty() {
         return None; // nothing to complete
     }
 
-    todo!("tokenize")
+    // this code should always reuse common parser,
+    // would be good for the parser to just return the last token with some context
+    let mut parser = line_parser::LineParser::new();
+    let mut commands = parser.parse_line(partial_cmdline)?;
+    let last_command_token = commands.pop()?.pop()?;
+
+    let match_tail = COMMANDS.contains(&last_command_token)?;
+
+    Some(
+        match_tail
+            .all_words()
+            .into_iter()
+            .map(|mut tail| {
+                if !partial_cmdline.ends_with(' ') {
+                    tail.push(' ');
+                }
+                tail
+            })
+            .map(|tail| format!("{partial_cmdline}{tail}"))
+            .collect(),
+    )
+}
+
+#[derive(Debug, Default)]
+pub struct Trie {
+    root: TrieNode,
+}
+
+#[derive(Debug, Default)]
+struct TrieNode {
+    is_end_of_word: bool,
+    children: HashMap<char, TrieNode>,
+}
+
+impl TrieNode {
+    fn new() -> Self {
+        Self {
+            is_end_of_word: false,
+            children: HashMap::new(),
+        }
+    }
+
+    /// return all words starting from the node
+    fn all_words(&self) -> Vec<String> {
+        let mut words = vec![];
+        let mut trail = vec![];
+        trail.push(("".to_string(), self));
+
+        while let Some((head, node)) = trail.pop() {
+            for (next_char, next_node) in &node.children {
+                trail.push((format!("{head}{next_char}"), next_node));
+            }
+            if node.is_end_of_word {
+                words.push(head);
+            }
+        }
+
+        words
+    }
+}
+
+impl Trie {
+    fn new() -> Self {
+        Trie {
+            root: TrieNode::new(),
+        }
+    }
+
+    fn insert(&mut self, word: &str) {
+        let mut current_node = &mut self.root;
+
+        for c in word.chars() {
+            current_node = current_node.children.entry(c).or_insert(TrieNode::new());
+        }
+        current_node.is_end_of_word = true;
+    }
+
+    /// None - doesn't contain
+    /// Some(node) - the very last node
+    fn contains(&self, word: &str) -> Option<&TrieNode> {
+        let mut current_node = &self.root;
+
+        for c in word.chars() {
+            match current_node.children.get(&c) {
+                Some(node) => current_node = node,
+                None => return None,
+            }
+        }
+
+        Some(current_node)
+    }
 }

--- a/src/bin/rush/src/lib.rs
+++ b/src/bin/rush/src/lib.rs
@@ -1,5 +1,6 @@
 use std::sync::Mutex;
 
+mod autocomplete;
 mod exec;
 mod line_parser;
 mod redirect;

--- a/src/bin/rush/src/term.rs
+++ b/src/bin/rush/src/term.rs
@@ -438,17 +438,10 @@ impl Term {
                         }
                     }
                     EscapesIn::Tab => {
-                        // TODO: store string right away
                         match autocomplete::try_complete(&self.line[..]) {
-                            Some(mut complete_options) => {
+                            Some(suggestion) => {
                                 self.typed_line = self.line.clone();
-                                // TODO: measure distance ?
-                                self.line = if let Some(fo) = complete_options.pop() {
-                                    fo
-                                } else {
-                                    self.beep();
-                                    continue;
-                                };
+                                self.line = suggestion;
                                 self.current_pos = self.line.len() as u32;
                                 self.redraw_line();
                             }

--- a/src/bin/rush/src/term.rs
+++ b/src/bin/rush/src/term.rs
@@ -439,9 +439,20 @@ impl Term {
                     }
                     EscapesIn::Tab => {
                         // TODO: store string right away
-                        let completed_line = autocomplete::try_complete(&self.line[..]);
-                        if let Some(completed_line) = completed_line {
-                            self.line = completed_line.into();
+                        match autocomplete::try_complete(&self.line[..]) {
+                            Some(mut complete_options) => {
+                                self.typed_line = self.line.clone();
+                                // TODO: measure distance ?
+                                self.line = if let Some(fo) = complete_options.pop() {
+                                    fo
+                                } else {
+                                    self.beep();
+                                    continue;
+                                };
+                                self.current_pos = self.line.len() as u32;
+                                self.redraw_line();
+                            }
+                            None => self.beep(),
                         }
                     }
                     EscapesIn::CtrlC => {


### PR DESCRIPTION
That's a basic framework for https://github.com/moturus/motor-os/issues/33.
I had to switch `term` from `u8` to `char` to re-use parser for tokenization. Although parser needs some refactoring too, I think it's useful to make it bound to autocompletion right away.

There's also some refactoring in `exec` to easily tell builtin commands from binaries. Ideally, I'd use [strum](https://docs.rs/strum/latest/strum/derive.EnumIter.html) to avoid static lists of builtins and just collect all options in runtime to a complete list.

**It's PITA to work with forks. Could you consider allowing branches ?**